### PR TITLE
Include subdirectories option (Closes #9)

### DIFF
--- a/src/Expelibrum/Expelibrum.UI/MainWindow.xaml
+++ b/src/Expelibrum/Expelibrum.UI/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:Expelibrum.UI"
         xmlns:view="clr-namespace:Expelibrum.UI.Views"
         mc:Ignorable="d"
-        Title="MainWindow" Height="200" Width="400" ResizeMode="NoResize">
+        Title="MainWindow" Height="250" Width="400" ResizeMode="NoResize">
     
     <Grid>
         <view:ProcessView DataContext="{Binding ProcessViewModel}"/>

--- a/src/Expelibrum/Expelibrum.UI/ViewModels/ProcessViewModel.cs
+++ b/src/Expelibrum/Expelibrum.UI/ViewModels/ProcessViewModel.cs
@@ -19,7 +19,7 @@ namespace Expelibrum.UI.ViewModels
 
         private string _originDirectoryPath;
         private string _targetDirectoryPath;
-        private bool _includeSubdirectories;
+        private bool _includeSubdirectories = true;
 
         #endregion
 

--- a/src/Expelibrum/Expelibrum.UI/ViewModels/ProcessViewModel.cs
+++ b/src/Expelibrum/Expelibrum.UI/ViewModels/ProcessViewModel.cs
@@ -19,6 +19,7 @@ namespace Expelibrum.UI.ViewModels
 
         private string _originDirectoryPath;
         private string _targetDirectoryPath;
+        private bool _includeSubdirectories;
 
         #endregion
 
@@ -39,6 +40,16 @@ namespace Expelibrum.UI.ViewModels
             set
             {
                 _targetDirectoryPath = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool IncludeSubdirectories
+        {
+            get => _includeSubdirectories;
+            set 
+            { 
+                _includeSubdirectories = value;
                 OnPropertyChanged();
             }
         }
@@ -66,8 +77,9 @@ namespace Expelibrum.UI.ViewModels
         private async void OnProcessFiles(object param)
         {
             var directory = new DirectoryInfo(OriginDirectoryPath);
+            var searchOption = (SearchOption)Convert.ToInt32(IncludeSubdirectories);
 
-            foreach (var file in directory.GetFiles("*.pdf"))
+            foreach (var file in directory.GetFiles("*.pdf", searchOption))
             {
                 try
                 {

--- a/src/Expelibrum/Expelibrum.UI/Views/ProcessView.xaml
+++ b/src/Expelibrum/Expelibrum.UI/Views/ProcessView.xaml
@@ -5,8 +5,13 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Expelibrum.UI.Views"
              mc:Ignorable="d" 
-             d:DesignHeight="150" d:DesignWidth="400">
+             d:DesignHeight="200" d:DesignWidth="400">
     <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Margin="15">
+
+        <WrapPanel Margin="5">
+            <CheckBox Margin="1" IsChecked="{Binding IncludeSubdirectories}"/>
+            <TextBlock Margin="4 0" VerticalAlignment="Center" Text="Include Subdirectories"/>
+        </WrapPanel>
 
         <TextBlock Text="Origin Directory" Margin="3,3,0,0" FontWeight="DemiBold"/>
         <WrapPanel HorizontalAlignment="Center" Margin="5">


### PR DESCRIPTION
Closes #9 

Added a checkbox so that the user can select whether or not he wants the processer to include files inside Origin's subdirectories.